### PR TITLE
Breadcrumb

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,6 +1,7 @@
 import PostEditPage from "./PostEditPage.js";
 import PostSidebar from "./PostSidebar.js";
 import { initRouter } from "../utils/router.js";
+import Breadcrumb from "./Breadcrumb.js";
 
 export default function App({ $target }) {
   const $postSideBarContainer = document.createElement("div");
@@ -25,6 +26,11 @@ export default function App({ $target }) {
     },
   });
 
+  const breadcrumb = new Breadcrumb({
+    $target: $postEditContainer,
+    postId: "new",
+  });
+
   this.route = () => {
     const { pathname } = window.location;
 
@@ -33,6 +39,7 @@ export default function App({ $target }) {
     if (pathname !== "/" && pathname.indexOf("/") === 0) {
       const [, , postId] = pathname.split("/");
       postEditPage.setState({ postId });
+      breadcrumb.setState({ postId });
     }
   };
 

--- a/src/components/Breadcrumb.js
+++ b/src/components/Breadcrumb.js
@@ -1,0 +1,41 @@
+export default function Breadcrumb({ $target, postId }) {
+  const $breadcrumb = document.createElement("div");
+  $breadcrumb.className = "breadcrumb";
+
+  this.state = postId;
+
+  $target.appendChild($breadcrumb);
+
+  this.setState = (nextState) => {
+    this.state = nextState;
+    this.render();
+  };
+
+  this.render = () => {
+    $breadcrumb.innerHTML = `
+        
+    `;
+  };
+
+  this.makeBreadcrumb = async (postId) => {
+    const documents = await getData("/documents");
+    let breadcrumb = {}
+    for (let i = 0; )
+  }
+}
+this.render();
+
+$breadcrumb.addEventListener("keyup", (e) => {
+  const { target } = e;
+
+  const name = target.getAttribute("name");
+
+  if (this.state[name] !== undefined) {
+    const nextState = {
+      ...this.state,
+      [name]: target.value,
+    };
+    this.setState(nextState);
+    onEditing(this.state);
+  }
+});

--- a/src/components/Breadcrumb.js
+++ b/src/components/Breadcrumb.js
@@ -1,41 +1,46 @@
+import { getData } from "../utils/api.js";
+
 export default function Breadcrumb({ $target, postId }) {
   const $breadcrumb = document.createElement("div");
   $breadcrumb.className = "breadcrumb";
+  const breadcrumb = {};
 
   this.state = postId;
 
   $target.appendChild($breadcrumb);
 
-  this.setState = (nextState) => {
+  this.setState = async (nextState) => {
     this.state = nextState;
+    const documents = await getData("/documents");
+    this.makeBreadcrumb(false, documents);
+    console.log(breadcrumb);
     this.render();
   };
 
   this.render = () => {
-    $breadcrumb.innerHTML = `
-        
-    `;
+    const targetDocument = breadcrumb[this.state];
+    targetDocument.forEach((item) => {
+      $documentLink = document.createElement("div");
+      $documentLink.textContent = item[0];
+      $breadcrumb.appendChild($documentLink);
+    });
   };
 
-  this.makeBreadcrumb = async (postId) => {
-    const documents = await getData("/documents");
-    let breadcrumb = {}
-    for (let i = 0; )
-  }
+  this.makeBreadcrumb = async (targetItem, data) => {
+    data.forEach(({ title, documents, id }) => {
+      targetItem
+        ? targetItem.push([title, id])
+        : (breadcrumb[id] = [[title, id]]);
+
+      if (documents.length > 0) {
+        this.makeBreadcrumb(breadcrumb[id], documents);
+      } else {
+        this.makeBreadcrumb(false, documents);
+      }
+    });
+  };
+
+  $breadcrumb.addEventListener("keyup", (e) => {
+    const { target } = e;
+  });
 }
-this.render();
-
-$breadcrumb.addEventListener("keyup", (e) => {
-  const { target } = e;
-
-  const name = target.getAttribute("name");
-
-  if (this.state[name] !== undefined) {
-    const nextState = {
-      ...this.state,
-      [name]: target.value,
-    };
-    this.setState(nextState);
-    onEditing(this.state);
-  }
-});

--- a/src/components/PostItem.js
+++ b/src/components/PostItem.js
@@ -22,24 +22,28 @@ export default function PostItem(title, id) {
   const $postSubItemBox = document.createElement("ul");
 
   $postItemBox.appendChild($li);
-  $postItemBox.append($postSubItemBox);
+  $postItemBox.appendChild($postSubItemBox);
 
   $li.addEventListener("click", async (e) => {
     const target = e.target;
     if (target.closest("span") === $title) {
       pushRouter(`/documents/${$title.className}`);
     } else if (target.closest("div") === $addButton) {
-      const createdPost = await postData($addButton.querySelector("button").className);
+      const createdPost = await postData(
+        $addButton.querySelector("button").className
+      );
       pushRouter(`/documents/${createdPost.id}`);
     } else if (target.closest("div") === $removeButton) {
       alert("문서가 정상적으로 삭제되었습니다.");
-      await deleteData($removeButton.querySelector("button").className).then((res) => {
-        if (res.parent) pushRouter(`/documents/${res.parent.id}`);
-        else {
-          pushRouter(`/`);
-          location.reload();
+      await deleteData($removeButton.querySelector("button").className).then(
+        (res) => {
+          if (res.parent) pushRouter(`/documents/${res.parent.id}`);
+          else {
+            pushRouter(`/`);
+            location.reload();
+          }
         }
-      });
+      );
     }
   });
 


### PR DESCRIPTION
현재 로직 에러 수정중입니다 ㅠㅠ

생각한 로직
api get 을 이용해 데이터들을 모두 불러들인 뒤 루트 노드의 아이디를 키 값으로 value에 breadcrumb를 리스트 [title, id] 형식으로 넣으려고 했습니다. 
그런 뒤 클릭한 문서의 아이디를 받아 해당 아이디의 breadcrumb를 출력하려 했고, 화면에는 title이 보이도록, 해당 문서로 클릭 이동할 때에는 id를 이용하려고 했습니다.

문제점
breadcrumb 딕셔너리에 이상한 형태로 값이 넣어져서 현재 계속 수정 중입니다... 


혹시 해당 로직보다 더 효율적인 로직이 있다면 조언 부탁드립니다.
또는 딕셔너리에 어떤 형태로 값을 넣으면 에러가 수정될 지 조언 부탁드립니다. ㅜㅠ