### PR TITLE
Breadcrumb 구현 완료

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,6 @@
   <body>
     <main id="app"></main>
     <link rel="stylesheet" href="style.css" />
-    <script src="/src/main.js" type="module"></script>
+    <script src="./src/main.js" type="module"></script>
   </body>
 </html>

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,6 @@
-import PostEditPage from "./PostEditPage.js";
-import PostSidebar from "./PostSidebar.js";
-import { initRouter } from "../utils/router.js";
-import Breadcrumb from "./Breadcrumb.js";
+import PostEditPage from "./components/PostEditPage.js";
+import PostSidebar from "./components/PostSidebar.js";
+import { initRouter } from "./utils/router.js";
 
 export default function App({ $target }) {
   const $postSideBarContainer = document.createElement("div");
@@ -26,11 +25,6 @@ export default function App({ $target }) {
     },
   });
 
-  const breadcrumb = new Breadcrumb({
-    $target: $postEditContainer,
-    postId: "new",
-  });
-
   this.route = () => {
     const { pathname } = window.location;
 
@@ -39,7 +33,6 @@ export default function App({ $target }) {
     if (pathname !== "/" && pathname.indexOf("/") === 0) {
       const [, , postId] = pathname.split("/");
       postEditPage.setState({ postId });
-      breadcrumb.setState({ postId });
     }
   };
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,6 +1,7 @@
 import PostEditPage from "./PostEditPage.js";
 import PostSidebar from "./PostSidebar.js";
 import { initRouter } from "../utils/router.js";
+import Breadcrumb from "./Breadcrumb.js";
 
 export default function App({ $target }) {
   const $postSideBarContainer = document.createElement("div");
@@ -25,6 +26,11 @@ export default function App({ $target }) {
     },
   });
 
+  const breadcrumb = new Breadcrumb({
+    $target: $postEditContainer,
+    postId: "new",
+  });
+
   this.route = () => {
     const { pathname } = window.location;
 
@@ -33,6 +39,7 @@ export default function App({ $target }) {
     if (pathname !== "/" && pathname.indexOf("/") === 0) {
       const [, , postId] = pathname.split("/");
       postEditPage.setState({ postId });
+      breadcrumb.setState({ postId });
     }
   };
 

--- a/src/components/Breadcrumb.js
+++ b/src/components/Breadcrumb.js
@@ -1,0 +1,41 @@
+export default function Breadcrumb({ $target, postId }) {
+  const $breadcrumb = document.createElement("div");
+  $breadcrumb.className = "breadcrumb";
+
+  this.state = postId;
+
+  $target.appendChild($breadcrumb);
+
+  this.setState = (nextState) => {
+    this.state = nextState;
+    this.render();
+  };
+
+  this.render = () => {
+    $breadcrumb.innerHTML = `
+        
+    `;
+  };
+
+  this.makeBreadcrumb = async (postId) => {
+    const documents = await getData("/documents");
+    let breadcrumb = {}
+    for (let i = 0; )
+  }
+}
+this.render();
+
+$breadcrumb.addEventListener("keyup", (e) => {
+  const { target } = e;
+
+  const name = target.getAttribute("name");
+
+  if (this.state[name] !== undefined) {
+    const nextState = {
+      ...this.state,
+      [name]: target.value,
+    };
+    this.setState(nextState);
+    onEditing(this.state);
+  }
+});

--- a/src/components/Breadcrumb.js
+++ b/src/components/Breadcrumb.js
@@ -1,41 +1,46 @@
+import { getData } from "../utils/api.js";
+
 export default function Breadcrumb({ $target, postId }) {
   const $breadcrumb = document.createElement("div");
   $breadcrumb.className = "breadcrumb";
+  const breadcrumb = {};
 
   this.state = postId;
 
   $target.appendChild($breadcrumb);
 
-  this.setState = (nextState) => {
+  this.setState = async (nextState) => {
     this.state = nextState;
+    const documents = await getData("/documents");
+    this.makeBreadcrumb(false, documents);
+    console.log(breadcrumb);
     this.render();
   };
 
   this.render = () => {
-    $breadcrumb.innerHTML = `
-        
-    `;
+    const targetDocument = breadcrumb[this.state];
+    targetDocument.forEach((item) => {
+      $documentLink = document.createElement("div");
+      $documentLink.textContent = item[0];
+      $breadcrumb.appendChild($documentLink);
+    });
   };
 
-  this.makeBreadcrumb = async (postId) => {
-    const documents = await getData("/documents");
-    let breadcrumb = {}
-    for (let i = 0; )
-  }
+  this.makeBreadcrumb = async (targetItem, data) => {
+    data.forEach(({ title, documents, id }) => {
+      targetItem
+        ? targetItem.push([title, id])
+        : (breadcrumb[id] = [[title, id]]);
+
+      if (documents.length > 0) {
+        this.makeBreadcrumb(breadcrumb[id], documents);
+      } else {
+        this.makeBreadcrumb(false, documents);
+      }
+    });
+  };
+
+  $breadcrumb.addEventListener("keyup", (e) => {
+    const { target } = e;
+  });
 }
-this.render();
-
-$breadcrumb.addEventListener("keyup", (e) => {
-  const { target } = e;
-
-  const name = target.getAttribute("name");
-
-  if (this.state[name] !== undefined) {
-    const nextState = {
-      ...this.state,
-      [name]: target.value,
-    };
-    this.setState(nextState);
-    onEditing(this.state);
-  }
-});

--- a/src/components/PostEditPage.js
+++ b/src/components/PostEditPage.js
@@ -1,8 +1,16 @@
 import { getData, putData } from "../utils/api.js";
 import Editor from "./Editor.js";
 import { pushRouter } from "../utils/router.js";
+import Breadcrumb from "./Breadcrumb.js";
 
 export default function PostEditPage({ $target, initialState }) {
+  const $editorContainer = document.createElement("div");
+  const $breadcrumbContainer = document.createElement("div");
+  $target.appendChild($breadcrumbContainer);
+  $target.appendChild($editorContainer);
+  $editorContainer.className = "editor-container";
+  $breadcrumbContainer.className = "breadcrumb-container";
+
   const INTERVAL_SAVE_TIME = 2000;
 
   this.state = initialState;
@@ -10,7 +18,7 @@ export default function PostEditPage({ $target, initialState }) {
   let timer = null;
 
   const editor = new Editor({
-    $target,
+    $target: $editorContainer,
     initialState: {
       title: "",
       content: "",
@@ -31,6 +39,11 @@ export default function PostEditPage({ $target, initialState }) {
     },
   });
 
+  const breadcrumb = new Breadcrumb({
+    $target: $breadcrumbContainer,
+    initialState: [],
+  });
+
   this.setState = async (nextState) => {
     if (this.state.postId !== nextState.postId) {
       this.state = nextState;
@@ -46,6 +59,9 @@ export default function PostEditPage({ $target, initialState }) {
         content: "",
       }
     );
+
+    const documents = await getData("/documents");
+    breadcrumb.setState(documents);
   };
 
   const getDocument = async () => {

--- a/src/components/PostItem.js
+++ b/src/components/PostItem.js
@@ -1,4 +1,4 @@
-import { deleteData, getData, postData } from "../utils/api.js";
+import { deleteData, postData } from "../utils/api.js";
 import { pushRouter } from "../utils/router.js";
 
 export default function PostItem(title, id) {

--- a/src/components/PostItem.js
+++ b/src/components/PostItem.js
@@ -22,24 +22,28 @@ export default function PostItem(title, id) {
   const $postSubItemBox = document.createElement("ul");
 
   $postItemBox.appendChild($li);
-  $postItemBox.append($postSubItemBox);
+  $postItemBox.appendChild($postSubItemBox);
 
   $li.addEventListener("click", async (e) => {
     const target = e.target;
     if (target.closest("span") === $title) {
       pushRouter(`/documents/${$title.className}`);
     } else if (target.closest("div") === $addButton) {
-      const createdPost = await postData($addButton.querySelector("button").className);
+      const createdPost = await postData(
+        $addButton.querySelector("button").className
+      );
       pushRouter(`/documents/${createdPost.id}`);
     } else if (target.closest("div") === $removeButton) {
       alert("문서가 정상적으로 삭제되었습니다.");
-      await deleteData($removeButton.querySelector("button").className).then((res) => {
-        if (res.parent) pushRouter(`/documents/${res.parent.id}`);
-        else {
-          pushRouter(`/`);
-          location.reload();
+      await deleteData($removeButton.querySelector("button").className).then(
+        (res) => {
+          if (res.parent) pushRouter(`/documents/${res.parent.id}`);
+          else {
+            pushRouter(`/`);
+            location.reload();
+          }
         }
-      });
+      );
     }
   });
 

--- a/src/components/PostSidebar.js
+++ b/src/components/PostSidebar.js
@@ -21,7 +21,7 @@ export default function PostSidebar({ $target }) {
     this.render();
   };
 
-  this.render = async () => {
+  this.render = () => {
     $createButton.textContent = "문서 생성하기";
     $title.textContent = "Notion Project";
     $target.appendChild($title);

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import App from "./components/App.js";
+import App from "./App.js";
 
 const $target = document.querySelector("#app");
 $target.className = "contentWrap";

--- a/style.css
+++ b/style.css
@@ -22,7 +22,7 @@ span {
 }
 
 span::before {
-  content:"\f56b";
+  content: "\f56b";
   display: inline-block;
   font-family: "Font Awesome 5 Free";
   font-weight: 900;
@@ -121,5 +121,22 @@ textarea {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding: 0px 50px 0px 50px;
+  padding: 0 50px;
+}
+
+.breadcrumb {
+  display: flex;
+  justify-content: center;
+  padding: 10px 50px;
+}
+
+.breadcrumb > div {
+  padding: 0 12px;
+  font-weight: bold;
+  font-size: 14px;
+}
+
+.breadcrumb > div:hover {
+  font-size: 16px;
+  color: rgb(64, 64, 64);
 }


### PR DESCRIPTION
늦게 pr 올려서 죄송합니다.  ㅠㅠ

breadcrumb 구현 완료했습니다.
- root부터 부모 문서 간의 path를 보여줍니다.
- path에 있는 타이틀을 클릭할 경우 해당 문서로 이동합니다.

구현 방법
(혜진님과 호원님 조언이 많이 도움되었습니다.)
- 문서 리스트를 api를 통해 불러오기(state로 관리)
- 순회하면서 모든 문서의 각 path를 저장한 dictionary 만들기(breadcrumb에 key : id, value [[title, id], [title, id] ....])
- 해당 문서의 postId를 찾아 breadcrumb[postId]를 통해 path 가져오기
- 화면에 보여주기

<img width="806" alt="image" src="https://github.com/Lim-JiSeon/FEDC4-5_Project_Notion_VanillaJS/assets/83554018/7ba94b6e-6af5-4720-9159-ef28eb630b3c">


Breadcrumb.js 파일 중점으로 수정했습니다. 

다음 목표는 아코디언?식으로 하위 문서들이 접히는 기능을 만들고 싶습니다.(안 보였다가 다시 보이게 하는 식으로)
가능하다면 디자인 부분도 노션과 더욱 비슷하게 수정하고 싶습니다. 

Breadcrumb를 구현하는 방식에 대해 피드백 부탁드립니다.(괜찮은지,,,?)
하위 문서가 접히는 아코디언 토글? 방식 구현과 관련해 조언해주실 부분이 있다면 부탁드립니다.
추가적으로 rich한 노션 서비스를 위해 필요한 기능들이 있다면 추천 부탁드립니다.
